### PR TITLE
refactor(proposta): tipar status e substituir alerts por toast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "19.2.4",
         "react-hook-form": "^7.79.0",
         "shadcn": "^4.11.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3",
@@ -10119,6 +10120,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.79.0",
     "shadcn": "^4.11.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import AppShell from '@/components/layout/AppShell';
 import { ThemeProvider } from '@/components/theme-provider';
 import { QueryProvider } from '@/providers/QueryProvider';
+import { Toaster } from 'sonner';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -26,6 +27,12 @@ export default function RootLayout({
         >
           <QueryProvider>
             <AppShell>{children}</AppShell>
+
+            <Toaster
+              position="top-right"
+              richColors
+              closeButton
+            />
           </QueryProvider>
         </ThemeProvider>
       </body>

--- a/src/app/proposta/page.tsx
+++ b/src/app/proposta/page.tsx
@@ -1,11 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 import PropostaHero from "@/components/proposta/PropostaHero";
 import PropostaForm from "@/components/proposta/PropostaForm";
+import PropostaCard from "@/components/proposta/PropostaCard";
+
+import { propostaService } from "@/services/proposta.service";
+import { useAuthStore } from "@/store/useAuthStore";
+
+import type { Proposta } from "@/types/proposta.types";
+
+import { Loader2 } from "lucide-react";
 
 export default function PropostaPage() {
+
+  const user = useAuthStore(
+    (state) => state.user
+  );
+
+  const [loading, setLoading] =
+    useState(true);
+
+  const [proposta, setProposta] =
+    useState<Proposta | null>(null);
+
+  useEffect(() => {
+
+    async function loadProposta() {
+
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+
+      const { data, error } =
+        await propostaService.getByAluno(
+          user.id
+        );
+
+      if (!error && data) {
+        setProposta(data as Proposta);
+      }
+
+      setLoading(false);
+    }
+
+    loadProposta();
+
+  }, [user]);
+
   return (
     <div className="flex flex-col gap-8">
+
       <PropostaHero />
-      <PropostaForm />
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="size-8 animate-spin text-primary" />
+        </div>
+      ) : proposta ? (
+        <PropostaCard proposta={proposta} />
+      ) : (
+        <PropostaForm />
+      )}
+
     </div>
   );
 }

--- a/src/components/proposta/PropostaCard.tsx
+++ b/src/components/proposta/PropostaCard.tsx
@@ -1,0 +1,72 @@
+import type { Proposta } from "@/types/proposta.types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface PropostaCardProps {
+  proposta: Proposta;
+}
+
+export default function PropostaCard({
+  proposta,
+}: PropostaCardProps) {
+  return (
+    <Card className="border-white/10 bg-sidebar/50 shadow-lg backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="text-primary">
+          Minha Proposta de TCC
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Título
+          </p>
+          <p className="font-medium">
+            {proposta.titulo}
+          </p>
+        </div>
+
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Orientador
+          </p>
+          <p>{proposta.orientador}</p>
+        </div>
+
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Linha de Pesquisa
+          </p>
+          <p>{proposta.linha_pesquisa}</p>
+        </div>
+
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Status
+          </p>
+          <span className="rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+            {proposta.status}
+          </span>
+        </div>
+
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Data de Criação
+          </p>
+          <p>
+            {proposta.created_at
+              ? new Date(
+                  proposta.created_at
+                ).toLocaleDateString("pt-BR")
+              : "-"}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/proposta/PropostaForm.tsx
+++ b/src/components/proposta/PropostaForm.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { toast } from "sonner";
 
 export default function PropostaForm() {
 
@@ -37,12 +38,16 @@ export default function PropostaForm() {
     event.preventDefault();
 
     if (!titulo || !orientador || !linhaPesquisa || !justificativa) {
-      alert("Preencha todos os campos obrigatórios marcados com *.");
+      toast.error("Campos obrigatórios", {
+        description: "Preencha todos os campos antes de enviar.",
+      });
       return;
     }
 
     if (!user) {
-      alert("Usuário não autenticado.");
+      toast.error("Acesso Negado", {
+        description: "Usuário não autenticado.",
+      });
       return;
     }
 
@@ -69,7 +74,9 @@ export default function PropostaForm() {
 
       if (error) throw error;
 
-      alert("Proposta enviada com sucesso!");
+      toast.success("Proposta enviada", {
+        description: "Sua proposta foi enviada com sucesso.",
+      });
 
       // Limpar formulário
       setTitulo("");
@@ -87,7 +94,9 @@ export default function PropostaForm() {
       setReferencias("");
     } catch (error) {
       console.error(error);
-      alert("Erro ao salvar proposta. Tente novamente mais tarde.");
+      toast.error("Erro ao enviar proposta", {
+        description: "Não foi possível salvar a proposta.",
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/services/proposta.service.ts
+++ b/src/services/proposta.service.ts
@@ -1,7 +1,5 @@
 import { supabase } from "@/lib/supabase";
-import type {
-  NovaProposta,
-} from "@/types/proposta.types";
+import type { NovaProposta } from "@/types/proposta.types";
 
 export const propostaService = {
   async create(data: NovaProposta) {
@@ -12,13 +10,12 @@ export const propostaService = {
       .single();
   },
 
-  async getByAluno(
-    alunoId: string
-  ) {
+  async getByAluno(alunoId: string) {
     return supabase
       .from("propostas")
       .select("*")
-      .eq("aluno_id", alunoId);
+      .eq("aluno_id", alunoId)
+      .maybeSingle();
   },
 
   async getAll() {

--- a/src/types/proposta.types.ts
+++ b/src/types/proposta.types.ts
@@ -3,8 +3,17 @@ import {
   TablesInsert,
 } from "@/database.types";
 
+export type StatusProposta =
+  | "Aguardando Orientador"
+  | "Aceita"
+  | "Recusada";
+
 export type Proposta =
-  Tables<"propostas">;
+  Omit<Tables<"propostas">, "status"> & {
+    status: StatusProposta | null;
+  };
 
 export type NovaProposta =
-  TablesInsert<"propostas">;
+  Omit<TablesInsert<"propostas">, "status"> & {
+    status?: StatusProposta;
+  };


### PR DESCRIPTION
# US5 - Registro de Proposta de TCC

## Objetivo

Finalizar a migração da funcionalidade de submissão de proposta de TCC da Sprint 1 (LocalStorage) para a arquitetura atual baseada em Next.js, Supabase e Zustand.

## Alterações realizadas

* Implementada consulta de proposta do aluno via Supabase.
* Ajustado service para utilização de `maybeSingle()`.
* Criado componente `PropostaCard`.
* Implementada renderização condicional entre formulário e proposta existente.
* Adicionado estado de carregamento inicial.
* Criada tipagem forte para status da proposta.
* Substituídos `alert()` por notificações utilizando Sonner.
* Configurado Toaster global.