### PR TITLE
feat: implementa envio de solicitações de orientação

### DIFF
--- a/src/components/orientacao/OrientacaoForm.tsx
+++ b/src/components/orientacao/OrientacaoForm.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -7,11 +11,56 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useCreateOrientacao } from "@/hooks/useCreateOrientacao";
+import {
+  orientacaoSchema,
+  type OrientacaoSchema,
+} from "@/schemas/orientacao.schema";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export default function OrientacaoForm() {
+  const user = useAuthStore((state) => state.user);
+  const createOrientacao = useCreateOrientacao();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<OrientacaoSchema>({
+    resolver: zodResolver(orientacaoSchema),
+    defaultValues: {
+      id_professor: "",
+      mensagem: "",
+    },
+  });
+
   const inputClassName =
     "w-full rounded-lg border border-white/10 bg-black/20 p-3 text-foreground placeholder:text-white/30 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50";
   const labelClassName = "mb-2 block text-sm font-medium text-foreground/90";
+
+  async function onSubmit(data: OrientacaoSchema) {
+    if (!user?.id) {
+      toast.error("Usuário não autenticado.");
+      return;
+    }
+
+    try {
+      await createOrientacao.mutateAsync({
+        aluno_id: user.id,
+        professor_id: data.id_professor,
+        mensagem: data.mensagem,
+        status: "pendente",
+      });
+
+      toast.success("Solicitação enviada com sucesso!");
+      reset();
+    } catch {
+      toast.error("Erro ao enviar solicitação de orientação.");
+    }
+  }
+
+  const isSending = isSubmitting || createOrientacao.isPending;
 
   return (
     <Card className="border-white/10 bg-sidebar/50 shadow-lg backdrop-blur-sm">
@@ -22,28 +71,49 @@ export default function OrientacaoForm() {
       </CardHeader>
 
       <CardContent className="pt-6">
-        <form className="space-y-6">
+        <form className="space-y-6" onSubmit={handleSubmit(onSubmit)}>
           <div>
             <label className={labelClassName}>Professor *</label>
-            <select className={`${inputClassName} cursor-pointer`}>
+            <select
+              {...register("id_professor")}
+              className={`${inputClassName} cursor-pointer`}
+              disabled={isSending}
+            >
               <option value="">Selecione um professor...</option>
+              {/* TODO: Substituir pelas options dinâmicas da T6.2. */}
+              <option value="44b9b946-e9df-44c7-a429-96af90e7c897">
+                Professor Teste (Mock)
+              </option>
             </select>
+            {errors.id_professor && (
+              <p className="mt-2 text-sm text-red-500">
+                {errors.id_professor.message}
+              </p>
+            )}
           </div>
 
           <div>
             <label className={labelClassName}>Mensagem *</label>
             <textarea
+              {...register("mensagem")}
               rows={5}
               placeholder="Escreva uma mensagem ao professor..."
               className={inputClassName}
+              disabled={isSending}
             />
+            {errors.mensagem && (
+              <p className="mt-2 text-sm text-red-500">
+                {errors.mensagem.message}
+              </p>
+            )}
           </div>
 
           <Button
             type="submit"
             className="w-full bg-primary text-primary-foreground hover:bg-primary/90 md:w-auto md:px-10"
+            disabled={isSending}
           >
-            Enviar Solicitação
+            {isSending ? "Enviando..." : "Enviar Solicitação"}
           </Button>
         </form>
       </CardContent>

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -125,6 +125,7 @@ export type Database = {
           aluno_id: string | null
           created_at: string | null
           id: string
+          mensagem: string | null
           professor_id: string | null
           proposta_id: string | null
           status: string | null
@@ -133,6 +134,7 @@ export type Database = {
           aluno_id?: string | null
           created_at?: string | null
           id?: string
+          mensagem?: string | null
           professor_id?: string | null
           proposta_id?: string | null
           status?: string | null
@@ -141,6 +143,7 @@ export type Database = {
           aluno_id?: string | null
           created_at?: string | null
           id?: string
+          mensagem?: string | null
           professor_id?: string | null
           proposta_id?: string | null
           status?: string | null

--- a/src/database/policies.sql
+++ b/src/database/policies.sql
@@ -23,3 +23,9 @@ on temas
 for all
 using (true)
 with check (true);
+
+create policy "allow authenticated students to create orientacoes"
+on orientacoes
+for insert
+to authenticated
+with check ((select auth.uid()) = aluno_id);

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -73,6 +73,8 @@ create table orientacoes (
 
     proposta_id uuid references propostas(id),
 
+    mensagem text,
+
     status text default 'ativa',
 
     created_at timestamp default now()

--- a/src/hooks/useCreateOrientacao.ts
+++ b/src/hooks/useCreateOrientacao.ts
@@ -1,0 +1,33 @@
+import {
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import {
+  orientacaoService,
+  type NovaOrientacao,
+} from "@/services/orientacao.service";
+
+export function useCreateOrientacao() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (orientacao: NovaOrientacao) => {
+      const { data, error } =
+        await orientacaoService.create(orientacao);
+
+      if (error) throw error;
+
+      return data;
+    },
+
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: [
+          "orientacoes",
+          variables.aluno_id,
+        ],
+      });
+    },
+  });
+}

--- a/src/schemas/orientacao.schema.ts
+++ b/src/schemas/orientacao.schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const orientacaoSchema = z.object({
+  id_professor: z.string().min(1, "Selecione um professor."),
+  mensagem: z
+    .string()
+    .min(10, "A mensagem deve possuir pelo menos 10 caracteres."),
+});
+
+export type OrientacaoSchema = z.infer<typeof orientacaoSchema>;

--- a/src/services/orientacao.service.ts
+++ b/src/services/orientacao.service.ts
@@ -1,0 +1,15 @@
+import { supabase } from "@/lib/supabase";
+import type { Database } from "@/database.types";
+
+export type NovaOrientacao =
+  Database["public"]["Tables"]["orientacoes"]["Insert"];
+
+export const orientacaoService = {
+  async create(data: NovaOrientacao) {
+    return supabase
+      .from("orientacoes")
+      .insert(data)
+      .select()
+      .single();
+  },
+};


### PR DESCRIPTION


## Principais Alterações:
* **Validação:** Implementado `react-hook-form` com `zod` para garantir que apenas solicitações completas sejam enviadas.
* **Integração:** Criado serviço e hook (`useCreateOrientacao`) para persistência no Supabase.
* **Persistência:** Adicionada a coluna `mensagem` na tabela `orientacoes` e configurada política de RLS para permitir a inserção pelo aluno.
* **UX:** Feedback visual com `sonner` (toasts) e estado de loading durante o envio.
* **Mock:** Incluído professor temporário para testes de fluxo, conforme alinhado com a T6.2.

