### PR TITLE
refactor: conclui migração da listagem de alunos para React + Supabase

### DIFF
--- a/src/hooks/useAlunos.ts
+++ b/src/hooks/useAlunos.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { userService } from "@/services/user.service";
+import type { User } from "@/types/user.types";
 
 export function useAlunos() {
-  return useQuery({
+  return useQuery<User[]>({
     queryKey: ["alunos"],
 
     queryFn: async () => {
-      const { data, error } =
-        await userService.getAlunos();
+      const { data, error } = await userService.getAlunos();
 
       if (error) {
         throw error;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -16,7 +16,8 @@ export const userService = {
       .in("status", activeStatuses);
   },
 
-  async getAlunos() {
+  // Busca todos os alunos ativos/aprovados
+  async getAlunos(): Promise<PostgrestSingleResponse<User[]>> {
     return await supabase
       .from("users")
       .select("*")


### PR DESCRIPTION
## Objetivo

Migrar a listagem de alunos da Sprint 1 para a nova arquitetura utilizando Next.js, TypeScript, Supabase e TanStack Query.

## Implementado

- Página de alunos integrada ao Supabase
- Hook `useAlunos` utilizando React Query
- Consulta de alunos ativos via `userService`
- Renderização da tabela com estados de carregamento e lista vazia
- Preservação do layout da Sprint 1 na nova arquitetura

## Issues

- T3.5 Refatorar Consultas de Alunos