### PR TITLE
feat: adiciona policies RLS para criação e consulta de propostas

### DIFF
--- a/src/database/policies.sql
+++ b/src/database/policies.sql
@@ -29,3 +29,19 @@ on orientacoes
 for insert
 to authenticated
 with check ((select auth.uid()) = aluno_id);
+
+create policy "Aluno pode criar a propria proposta"
+on propostas
+for insert
+to authenticated
+with check (
+    auth.uid() = aluno_id
+);
+
+create policy "Aluno pode visualizar a propria proposta"
+on propostas
+for select
+to authenticated
+using (
+    auth.uid() = aluno_id
+);


### PR DESCRIPTION
## Objetivo

Adicionar as políticas de Row Level Security (RLS) da tabela `propostas`, permitindo que alunos autenticados possam criar e consultar suas próprias propostas na nova arquitetura utilizando Supabase.

## Implementado

* Adicionadas policies de INSERT para permitir que o aluno crie sua própria proposta
* Adicionadas policies de SELECT para permitir que o aluno visualize sua própria proposta
* Correção do erro `403 Forbidden` causado pela ausência de policies na tabela `propostas`
* Mantida a compatibilidade com a autenticação via Supabase Auth

## Issues

* T3.1 Configurar Policies RLS para Propostas