### PR TITLE
Feat/UI fila orientacoes

### DIFF
--- a/src/app/alunos/page.tsx
+++ b/src/app/alunos/page.tsx
@@ -1,8 +1,17 @@
+"use client";
+
 import AlunosTable from "@/components/alunos/AlunosTable";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useRequireCoordinator } from "@/hooks/useRequireCoordinator";
 import { Users } from "lucide-react";
 
 export default function AlunosPage() {
+  const { isAuthorized } = useRequireCoordinator();
+
+  if (!isAuthorized) {
+    return null;
+  }
+
   return (
     <div className="flex flex-col gap-8">
       <section className="relative overflow-hidden rounded-2xl border border-primary/20 bg-sidebar p-8 shadow-xl">

--- a/src/app/orientacao/page.tsx
+++ b/src/app/orientacao/page.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import OrientacaoForm from "@/components/orientacao/OrientacaoForm";
+import { useRequireRole } from "@/hooks/useRequireRole";
 import { GraduationCap } from "lucide-react";
 
 export default function OrientacaoPage() {
+  const { isAuthorized } = useRequireRole(["aluno"]);
+
+  if (!isAuthorized) {
+    return null;
+  }
+
   return (
     <div className="flex flex-col gap-8">
       <section className="relative overflow-hidden rounded-2xl border border-primary/20 bg-sidebar/50 p-8">

--- a/src/app/orientacoes-recebidas/page.tsx
+++ b/src/app/orientacoes-recebidas/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Inbox } from "lucide-react";
+
+import FilaOrientacoesTable from "@/components/orientacao/FilaOrientacoesTable";
+import { useRequireProfessor } from "@/hooks/useRequireProfessor";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function OrientacoesRecebidasPage() {
+  const { isAuthorized } = useRequireProfessor();
+
+  if (!isAuthorized) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="relative overflow-hidden rounded-2xl border border-primary/20 bg-sidebar/50 p-8">
+        <div className="relative z-10 flex items-center gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+            <Inbox className="size-6 text-primary" aria-hidden="true" />
+          </div>
+          <div>
+            <h1 className="font-heading text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              Solicitações Recebidas
+            </h1>
+            <p className="mt-2 text-lg text-foreground/70">
+              Acompanhe os pedidos de orientação enviados pelos alunos.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Card className="border-white/10 bg-sidebar/50 shadow-lg backdrop-blur-sm">
+        <CardHeader className="border-b border-white/5 pb-5">
+          <CardTitle className="font-heading text-xl text-primary">
+            Fila de Solicitações
+          </CardTitle>
+        </CardHeader>
+
+        <CardContent className="pt-6">
+          <FilaOrientacoesTable />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/professores/page.tsx
+++ b/src/app/professores/page.tsx
@@ -1,8 +1,17 @@
+"use client";
+
 import ProfessoresHero from "@/components/professores/ProfessoresHero";
 import ProfessoresTable from "@/components/professores/ProfessoresTable";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useRequireCoordinator } from "@/hooks/useRequireCoordinator";
 
 export default function ProfessoresPage() {
+  const { isAuthorized } = useRequireCoordinator();
+
+  if (!isAuthorized) {
+    return null;
+  }
+
   return (
     <div className="flex flex-col gap-8">
       <ProfessoresHero />

--- a/src/app/proposta/page.tsx
+++ b/src/app/proposta/page.tsx
@@ -4,6 +4,7 @@ import PropostaHero from "@/components/proposta/PropostaHero";
 import PropostaForm from "@/components/proposta/PropostaForm";
 import PropostaCard from "@/components/proposta/PropostaCard";
 
+import { useRequireRole } from "@/hooks/useRequireRole";
 import { useAuthStore } from "@/store/useAuthStore";
 
 import { Loader2 } from "lucide-react";
@@ -11,6 +12,7 @@ import { Loader2 } from "lucide-react";
 import { useProposta } from "@/hooks/useProposta";
 
 export default function PropostaPage() {
+  const { isAuthorized } = useRequireRole(["aluno"]);
   const user = useAuthStore(
     (state) => state.user
   );
@@ -19,6 +21,10 @@ export default function PropostaPage() {
     data: proposta,
     isLoading,
   } = useProposta(user?.id);
+
+  if (!isAuthorized) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/src/app/temas/page.tsx
+++ b/src/app/temas/page.tsx
@@ -4,7 +4,7 @@ import TemaForm from "@/components/temas/TemaForm";
 import TemasTable from "@/components/temas/TemasTable";
 import TemasHero from "@/components/temas/TemasHero";
 
-import { useRequireCoordinator } from "@/hooks/useRequireCoordinator";
+import { useRequireProfessor } from "@/hooks/useRequireProfessor";
 
 import {
   Card,
@@ -15,7 +15,7 @@ import {
 
 export default function TemasPage() {
   const { isAuthorized } =
-    useRequireCoordinator();
+    useRequireProfessor();
 
   if (!isAuthorized) {
     return null;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
+import {
+  canAccessRoute,
+  protectedRoutes,
+} from "@/config/rbac";
 import { clearStoredAuth } from "@/lib/auth-storage";
 import { authService } from "@/services/auth.service";
 import { useAuthStore } from "@/store/useAuthStore";
@@ -13,37 +17,15 @@ interface SidebarProps {
   onNavigate?: () => void;
 }
 
-interface NavItem {
-  label: string;
-  href: string;
-  roles?: string[];
-}
-
-const navItems: NavItem[] = [
-  { label: "Dashboard", href: "/dashboard" },
-  { label: "Administração", href: "/admin", roles: ["coordenador"] },
-  { label: "Professores", href: "/professores", roles: ["coordenador"] },
-  { label: "Alunos", href: "/alunos", roles: ["coordenador"] },
-  { label: "Temas", href: "/temas", roles: ["coordenador", "professor"] },
-  { label: "Proposta", href: "/proposta", roles: ["aluno"] },
-  { label: "Orientação", href: "/orientacao", roles: ["aluno"] },
-  {
-    label: "Orientações Recebidas",
-    href: "/orientacoes-recebidas",
-    roles: ["professor", "coordenador"],
-  },
-];
-
 export default function Sidebar({ isOpen = false, onNavigate }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const role = useAuthStore((state) => state.role);
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
-  const visibleNavItems = navItems.filter((item) => {
-    if (!item.roles) return true;
-    return role && item.roles.includes(role);
-  });
+  const visibleNavItems = protectedRoutes.filter((item) =>
+    canAccessRoute(item, role)
+  );
 
   async function handleLogout() {
     await authService.signOut();

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 
-import { clearStoredAuth } from '@/lib/auth-storage';
-import { authService } from '@/services/auth.service';
-import { useAuthStore } from '@/store/useAuthStore';
+import { clearStoredAuth } from "@/lib/auth-storage";
+import { authService } from "@/services/auth.service";
+import { useAuthStore } from "@/store/useAuthStore";
 
 interface SidebarProps {
   isOpen?: boolean;
@@ -20,13 +20,18 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Administração', href: '/admin', roles: ['coordenador'] },
-  { label: 'Professores', href: '/professores', roles: ['coordenador'] },
-  { label: 'Alunos', href: '/alunos', roles: ['coordenador'] },
-  { label: 'Temas', href: '/temas', roles: ['coordenador', 'professor'] },
-  { label: 'Proposta', href: '/proposta', roles: ['aluno'] },
-  { label: 'Orientação', href: '/orientacao', roles: ['aluno'] },
+  { label: "Dashboard", href: "/dashboard" },
+  { label: "Administração", href: "/admin", roles: ["coordenador"] },
+  { label: "Professores", href: "/professores", roles: ["coordenador"] },
+  { label: "Alunos", href: "/alunos", roles: ["coordenador"] },
+  { label: "Temas", href: "/temas", roles: ["coordenador", "professor"] },
+  { label: "Proposta", href: "/proposta", roles: ["aluno"] },
+  { label: "Orientação", href: "/orientacao", roles: ["aluno"] },
+  {
+    label: "Orientações Recebidas",
+    href: "/orientacoes-recebidas",
+    roles: ["professor", "coordenador"],
+  },
 ];
 
 export default function Sidebar({ isOpen = false, onNavigate }: SidebarProps) {
@@ -45,14 +50,14 @@ export default function Sidebar({ isOpen = false, onNavigate }: SidebarProps) {
     clearStoredAuth();
     clearAuth();
     onNavigate?.();
-    router.replace('/login');
+    router.replace("/login");
     router.refresh();
   }
 
   return (
     <aside
       className={`fixed top-0 z-50 flex h-screen w-[280px] flex-col border-r border-sidebar-border bg-sidebar px-5 py-4 text-sidebar-foreground shadow-xl transition-all duration-300 ease-in-out md:left-0 md:shadow-none ${
-        isOpen ? 'left-0' : '-left-[280px]'
+        isOpen ? "left-0" : "-left-[280px]"
       }`}
     >
       <div className="mb-8 w-full border-b border-sidebar-border pb-6 text-center">
@@ -79,11 +84,11 @@ export default function Sidebar({ isOpen = false, onNavigate }: SidebarProps) {
                 <Link
                   href={item.href}
                   onClick={onNavigate}
-                  aria-current={isActive ? 'page' : undefined}
+                  aria-current={isActive ? "page" : undefined}
                   className={`flex items-center rounded-xl px-4 py-3 font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
                     isActive
-                      ? 'bg-accent text-accent-foreground shadow-md shadow-accent/20'
-                      : 'text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-sm'
+                      ? "bg-accent text-accent-foreground shadow-md shadow-accent/20"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-sm"
                   }`}
                 >
                   <span>{item.label}</span>

--- a/src/components/orientacao/FilaOrientacoesTable.tsx
+++ b/src/components/orientacao/FilaOrientacoesTable.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  MailOpen,
+  XCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface OrientacaoRecebidaMock {
+  id: string;
+  aluno_nome: string;
+  mensagem: string;
+  status: "pendente";
+  created_at: string;
+}
+
+const orientacoesMock: OrientacaoRecebidaMock[] = [
+  {
+    id: "ori-001",
+    aluno_nome: "Ana Beatriz Lima",
+    mensagem:
+      "Professor, gostaria de solicitar sua orientação para um projeto sobre acessibilidade em plataformas educacionais. A proposta envolve mapear barreiras de uso em ambientes virtuais de aprendizagem e sugerir melhorias de interface para estudantes com deficiência visual.",
+    status: "pendente",
+    created_at: "2026-06-21T14:30:00.000Z",
+  },
+  {
+    id: "ori-002",
+    aluno_nome: "Carlos Eduardo Souza",
+    mensagem:
+      "Tenho interesse em desenvolver um trabalho sobre segurança da informação aplicada a sistemas acadêmicos. Minha ideia inicial é analisar riscos comuns em fluxos de autenticação e propor boas práticas para proteger dados sensíveis de alunos e professores.",
+    status: "pendente",
+    created_at: "2026-06-22T09:15:00.000Z",
+  },
+  {
+    id: "ori-003",
+    aluno_nome: "Mariana Costa Ribeiro",
+    mensagem:
+      "Gostaria de saber se o senhor poderia me orientar em um projeto de inteligência artificial para classificação de temas de TCC. A ideia é usar os textos das propostas para sugerir áreas de pesquisa e possíveis orientadores.",
+    status: "pendente",
+    created_at: "2026-06-23T18:45:00.000Z",
+  },
+];
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+export default function FilaOrientacoesTable() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [selectedOrientacao, setSelectedOrientacao] =
+    useState<OrientacaoRecebidaMock | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+
+    if (selectedOrientacao && dialog && !dialog.open) {
+      dialog.showModal();
+    }
+  }, [selectedOrientacao]);
+
+  function closeDialog() {
+    dialogRef.current?.close();
+    setSelectedOrientacao(null);
+  }
+
+  function handleAccept() {
+    toast.success("Aceito (Mock)");
+  }
+
+  function handleReject() {
+    toast.info("Recusado (Mock)");
+  }
+
+  return (
+    <>
+      <div className="w-full overflow-x-auto rounded-lg border border-white/10 bg-black/20">
+        <Table>
+          <TableHeader className="bg-white/5">
+            <TableRow className="border-white/10 hover:bg-transparent">
+              <TableHead className="font-semibold text-primary">
+                ALUNO
+              </TableHead>
+              <TableHead className="font-semibold text-primary">
+                DATA
+              </TableHead>
+              <TableHead className="font-semibold text-primary">
+                STATUS
+              </TableHead>
+              <TableHead className="text-center font-semibold text-primary">
+                AÇÕES
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {orientacoesMock.map((orientacao) => (
+              <TableRow
+                key={orientacao.id}
+                className="border-white/5 transition-colors hover:bg-white/5"
+              >
+                <TableCell className="font-medium text-white">
+                  {orientacao.aluno_nome}
+                </TableCell>
+                <TableCell className="text-white/70">
+                  {dateFormatter.format(new Date(orientacao.created_at))}
+                </TableCell>
+                <TableCell>
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary ring-1 ring-inset ring-primary/20">
+                    <span
+                      className="size-1.5 rounded-full bg-primary"
+                      aria-hidden="true"
+                    />
+                    Pendente
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setSelectedOrientacao(orientacao)}
+                    >
+                      <MailOpen className="size-4" aria-hidden="true" />
+                      Ler Mensagem
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="bg-emerald-600 text-white hover:bg-emerald-500"
+                      onClick={handleAccept}
+                    >
+                      <CheckCircle2 className="size-4" aria-hidden="true" />
+                      Aceitar
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="bg-red-600 text-white hover:bg-red-500"
+                      onClick={handleReject}
+                    >
+                      <XCircle className="size-4" aria-hidden="true" />
+                      Recusar
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <dialog
+        ref={dialogRef}
+        onCancel={() => setSelectedOrientacao(null)}
+        className="w-[min(92vw,640px)] rounded-xl border border-white/10 bg-card p-0 text-card-foreground shadow-2xl backdrop:bg-black/70"
+      >
+        {selectedOrientacao && (
+          <div className="flex flex-col">
+            <div className="border-b border-white/10 px-6 py-5">
+              <p className="text-sm font-medium uppercase tracking-wide text-primary">
+                Mensagem do aluno
+              </p>
+              <h2 className="mt-2 font-heading text-2xl font-bold text-white">
+                {selectedOrientacao.aluno_nome}
+              </h2>
+            </div>
+
+            <div className="px-6 py-5">
+              <p className="whitespace-pre-line text-sm leading-7 text-foreground/80">
+                {selectedOrientacao.mensagem}
+              </p>
+            </div>
+
+            <div className="flex justify-end border-t border-white/10 px-6 py-4">
+              <Button type="button" onClick={closeDialog}>
+                Fechar
+              </Button>
+            </div>
+          </div>
+        )}
+      </dialog>
+    </>
+  );
+}

--- a/src/components/orientacao/FilaOrientacoesTable.tsx
+++ b/src/components/orientacao/FilaOrientacoesTable.tsx
@@ -166,8 +166,9 @@ export default function FilaOrientacoesTable() {
 
       <dialog
         ref={dialogRef}
+        onClose={() => setSelectedOrientacao(null)}
         onCancel={() => setSelectedOrientacao(null)}
-        className="w-[min(92vw,640px)] rounded-xl border border-white/10 bg-card p-0 text-card-foreground shadow-2xl backdrop:bg-black/70"
+        className="fixed inset-0 m-auto max-h-[85vh] w-[min(92vw,640px)] max-w-none overflow-hidden rounded-xl border border-white/10 bg-card p-0 text-card-foreground shadow-2xl backdrop:bg-black/70"
       >
         {selectedOrientacao && (
           <div className="flex flex-col">

--- a/src/config/rbac.ts
+++ b/src/config/rbac.ts
@@ -1,0 +1,53 @@
+import {
+  AUTH_ROLES,
+  type AuthRole,
+} from "@/types/auth.types";
+
+export interface ProtectedRoute {
+  label: string;
+  href: string;
+  roles?: readonly AuthRole[];
+}
+
+export const protectedRoutes: readonly ProtectedRoute[] = [
+  { label: "Dashboard", href: "/dashboard" },
+  { label: "Administração", href: "/admin", roles: ["coordenador"] },
+  { label: "Professores", href: "/professores", roles: ["coordenador"] },
+  { label: "Alunos", href: "/alunos", roles: ["coordenador"] },
+  { label: "Temas", href: "/temas", roles: ["coordenador", "professor"] },
+  { label: "Proposta", href: "/proposta", roles: ["aluno"] },
+  { label: "Orientação", href: "/orientacao", roles: ["aluno"] },
+  {
+    label: "Orientações Recebidas",
+    href: "/orientacoes-recebidas",
+    roles: ["professor", "coordenador"],
+  },
+];
+
+export const privateRoutes = protectedRoutes.map((route) => route.href);
+
+export function isAuthRole(role: string | null | undefined): role is AuthRole {
+  return AUTH_ROLES.includes(role as AuthRole);
+}
+
+export function getProtectedRoute(pathname: string) {
+  return protectedRoutes.find(
+    (route) => pathname === route.href || pathname.startsWith(`${route.href}/`)
+  );
+}
+
+export function canAccessRoute(
+  route: ProtectedRoute,
+  role: AuthRole | null
+) {
+  if (!route.roles) return true;
+  return role ? route.roles.includes(role) : false;
+}
+
+export function canAccessPath(pathname: string, role: AuthRole | null) {
+  const route = getProtectedRoute(pathname);
+
+  if (!route) return true;
+
+  return canAccessRoute(route, role);
+}

--- a/src/hooks/useRequireCoordinator.ts
+++ b/src/hooks/useRequireCoordinator.ts
@@ -1,25 +1,5 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-
-import { useAuthStore } from "@/store/useAuthStore";
+import { useRequireRole } from "@/hooks/useRequireRole";
 
 export function useRequireCoordinator() {
-  const router = useRouter();
-
-  const role = useAuthStore(
-    (state) => state.role
-  );
-
-  useEffect(() => {
-    if (role && role !== "coordenador") {
-      router.replace("/dashboard");
-    }
-  }, [role, router]);
-
-  return {
-    isAuthorized: role === "coordenador",
-    role,
-  };
+  return useRequireRole(["coordenador"]);
 }

--- a/src/hooks/useRequireProfessor.ts
+++ b/src/hooks/useRequireProfessor.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAuthStore } from "@/store/useAuthStore";
+
+const authorizedRoles = ["professor", "coordenador"];
+
+export function useRequireProfessor() {
+  const router = useRouter();
+  const role = useAuthStore((state) => state.role);
+  const isAuthorized = role ? authorizedRoles.includes(role) : false;
+
+  useEffect(() => {
+    if (role && !isAuthorized) {
+      router.replace("/dashboard");
+    }
+  }, [isAuthorized, role, router]);
+
+  return {
+    isAuthorized,
+    role,
+  };
+}

--- a/src/hooks/useRequireProfessor.ts
+++ b/src/hooks/useRequireProfessor.ts
@@ -1,25 +1,5 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-
-import { useAuthStore } from "@/store/useAuthStore";
-
-const authorizedRoles = ["professor", "coordenador"];
+import { useRequireRole } from "@/hooks/useRequireRole";
 
 export function useRequireProfessor() {
-  const router = useRouter();
-  const role = useAuthStore((state) => state.role);
-  const isAuthorized = role ? authorizedRoles.includes(role) : false;
-
-  useEffect(() => {
-    if (role && !isAuthorized) {
-      router.replace("/dashboard");
-    }
-  }, [isAuthorized, role, router]);
-
-  return {
-    isAuthorized,
-    role,
-  };
+  return useRequireRole(["professor", "coordenador"]);
 }

--- a/src/hooks/useRequireRole.ts
+++ b/src/hooks/useRequireRole.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAuthStore } from "@/store/useAuthStore";
+import type { AuthRole } from "@/types/auth.types";
+
+export function useRequireRole(allowedRoles: readonly AuthRole[]) {
+  const router = useRouter();
+  const role = useAuthStore((state) => state.role);
+  const isAuthorized = role ? allowedRoles.includes(role) : false;
+
+  useEffect(() => {
+    if (role && !isAuthorized) {
+      router.replace("/dashboard");
+    }
+  }, [isAuthorized, role, router]);
+
+  return {
+    isAuthorized,
+    role,
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,17 +1,12 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import type { Database } from "@/database.types";
 
-const privateRoutes = [
-  "/dashboard",
-  "/admin",
-  "/temas",
-  "/alunos",
-  "/professores",
-  "/proposta",
-  "/orientacao",
-  "/orientacoes-recebidas",
-];
+import {
+  getProtectedRoute,
+  isAuthRole,
+  privateRoutes,
+} from "@/config/rbac";
+import type { Database } from "@/database.types";
 
 const publicRoutes = ["/login", "/register"];
 
@@ -80,6 +75,22 @@ export async function middleware(request: NextRequest) {
 
   if (user && (isRootRoute || isPublicRoute)) {
     return redirectTo("/dashboard");
+  }
+
+  const protectedRoute = getProtectedRoute(pathname);
+
+  if (user && protectedRoute?.roles) {
+    const { data: profile } = await supabase
+      .from("users")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const role = profile?.role?.toLowerCase();
+
+    if (!isAuthRole(role) || !protectedRoute.roles.includes(role)) {
+      return redirectTo("/dashboard");
+    }
   }
 
   return supabaseResponse;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ const privateRoutes = [
   "/professores",
   "/proposta",
   "/orientacao",
+  "/orientacoes-recebidas",
 ];
 
 const publicRoutes = ["/login", "/register"];


### PR DESCRIPTION

 Principais Alterações:
* **UI/Componentes:** Criado o componente `FilaOrientacoesTable` usando o padrão do `shadcn/ui`. Inclui ações de ler mensagem (via Modal nativo), Aceitar e Recusar (com feedback via `toast`).
* **Nova Rota:** Página `/orientacoes-recebidas` criada, integrada ao layout principal.
* **Controle de Acesso (RBAC):**
    * Criado o hook `useRequireProfessor` para restringir o acesso à página apenas para usuários com perfil de 'professor' ou 'coordenador'.
    * Atualização no `middleware.ts` para proteger a nova rota contra acessos não autorizados.
    * Sidebar atualizado para renderizar o link de forma condicional, garantindo que alunos não visualizem o menu de gestão de orientações.
* **Preparação para o Backend:** A estrutura de dados (mock) reflete exatamente os campos da tabela `orientacoes` no Supabase, facilitando a futura integração via query.

